### PR TITLE
Set minimum value for rough_mom and rough_heat to prevent NaN/Inf 

### DIFF
--- a/land_model.F90
+++ b/land_model.F90
@@ -351,8 +351,8 @@ subroutine land_model_init (cplr2land, land2cplr, time_init, time, dt_fast, dt_s
   land2cplr%albedo_nir_dir    = 0.0
   land2cplr%albedo_vis_dif    = 0.0
   land2cplr%albedo_nir_dif    = 0.0
-  land2cplr%rough_mom         = 0.0
-  land2cplr%rough_heat        = 0.0
+  land2cplr%rough_mom         = 1.0e-6
+  land2cplr%rough_heat        = 1.0e-6
   land2cplr%rough_scale       = 1.0
   land2cplr%discharge         = 0.0
   land2cplr%discharge_heat    = 0.0

--- a/land_model.F90
+++ b/land_model.F90
@@ -351,8 +351,8 @@ subroutine land_model_init (cplr2land, land2cplr, time_init, time, dt_fast, dt_s
   land2cplr%albedo_nir_dir    = 0.0
   land2cplr%albedo_vis_dif    = 0.0
   land2cplr%albedo_nir_dif    = 0.0
-  land2cplr%rough_mom         = 1.0e-6
-  land2cplr%rough_heat        = 1.0e-6
+  land2cplr%rough_mom         = 0.1
+  land2cplr%rough_heat        = 0.1
   land2cplr%rough_scale       = 1.0
   land2cplr%discharge         = 0.0
   land2cplr%discharge_heat    = 0.0

--- a/land_model.F90
+++ b/land_model.F90
@@ -351,8 +351,8 @@ subroutine land_model_init (cplr2land, land2cplr, time_init, time, dt_fast, dt_s
   land2cplr%albedo_nir_dir    = 0.0
   land2cplr%albedo_vis_dif    = 0.0
   land2cplr%albedo_nir_dif    = 0.0
-  land2cplr%rough_mom         = 0.1
-  land2cplr%rough_heat        = 0.1
+  land2cplr%rough_mom         = 1.0e-12
+  land2cplr%rough_heat        = 1.0e-12
   land2cplr%rough_scale       = 1.0
   land2cplr%discharge         = 0.0
   land2cplr%discharge_heat    = 0.0


### PR DESCRIPTION
When `rough_mom` or` rough_heat` is zero on the exchange grid, calculations of variables such as the friction velocity (**ex_u_star**) can result in **NaN** or **Inf**. This happens because the calculation of  `ex_u_star` involve divisions by `rough_mom`, e.g. logarithmic form of  `zref/rough_mom`.  Setting a minimum value for `rough_mom` and `rough_heat` prevents these numerical errors and model crash when output `ex_u_star`.